### PR TITLE
I think packages needed to be specified in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,8 @@ setup(
     author_email='davclark@berkeley.edu',
     license='BSD-2',
 
+    packages=['taq'],
+
     install_requires=['tables', 'pytz'],
 
     extras_require={


### PR DESCRIPTION
Without `packages=['taq'],` pip was not installing the package.